### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/helm/bitnami/clickhouse/values.yaml
+++ b/helm/bitnami/clickhouse/values.yaml
@@ -987,8 +987,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r22
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/helm/bitnami/postgresql/values.yaml
+++ b/helm/bitnami/postgresql/values.yaml
@@ -1443,8 +1443,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r24
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/terraform/devopscorner/devopspoc/eks/_manifest/10-redis-cluster-helm-update-dev.yaml
+++ b/terraform/devopscorner/devopspoc/eks/_manifest/10-redis-cluster-helm-update-dev.yaml
@@ -42,8 +42,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.6-debian-10-r146
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
 kubeVersion: ""
 master:
   affinity: {}

--- a/terraform/devopscorner/devopspoc/eks/_manifest/10-redis-cluster-helm-update-uat.yaml
+++ b/terraform/devopscorner/devopspoc/eks/_manifest/10-redis-cluster-helm-update-uat.yaml
@@ -42,8 +42,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.6-debian-10-r146
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
 kubeVersion: ""
 master:
   affinity: {}


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/redis:6.2.6-debian-10-r146` → [`soldevelo/redis:6.2.16-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/os-shell:12-debian-12-r24` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r22` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)